### PR TITLE
delay boot for 30 seconds in order to avoid sending data to UART duri…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -55,7 +55,7 @@ set VEHICLE_TYPE none
 # Print full system version.
 #
 ver all
-
+usleep 30000000
 #
 # Try to mount the microSD card.
 #


### PR DESCRIPTION
…ng UFEI boot.
