### PR TITLE
add default value for the PWM_AUX1, use RC_AUX1 by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -65,3 +65,13 @@ param set-default UXRCE_DDS_CFG 103
 param set-default NAV_RCL_ACT 0
 param set-default COM_RCL_EXCEPT 4
 param set-default NAV_DLL_ACT 0
+param set-default PWM_MAIN_FUNC8 407
+param set-default PWM_AUX_FUNC1 407
+param set-default PWM_MAIN_MIN8 800
+param set-default PWM_AUX_MIN1 800
+param set-default PWM_MAIN_MAX8 2200
+param set-default PWM_AUX_MAX1 2200
+param set-default PWM_MAIN_DIS8 1500
+param set-default PWM_MAIN_DIS1 1500
+
+


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
